### PR TITLE
Version 1x pin out Miss-match

### DIFF
--- a/src/SNESDev.c
+++ b/src/SNESDev.c
@@ -165,8 +165,8 @@ int main(int argc, char *argv[]) {
 		data2pin = RPI_GPIO_P1_07;
 		clockpin_v2 = RPI_V2_GPIO_P1_19;
 		strobepin_v2 = RPI_V2_GPIO_P1_23;
-		data1pin_v2 = RPI_V2_GPIO_P1_05;
-		data2pin_v2 = RPI_V2_GPIO_P1_07;
+		data1pin_v2 = RPI_V2_GPIO_P1_07;
+		data2pin_v2 = RPI_V2_GPIO_P1_05;
 		printf("[SNESDev-Rpi] Using pin setup for RetroPie GPIO-Adapter Version 1.X\n");
 
 	} else if (strcmp(confres.adapter_version,"2x")==0) {

--- a/src/SNESDev.c
+++ b/src/SNESDev.c
@@ -161,8 +161,8 @@ int main(int argc, char *argv[]) {
 	if (strcmp(confres.adapter_version,"1x")==0) {
 		clockpin = RPI_GPIO_P1_19;
 		strobepin = RPI_GPIO_P1_23;
-		data1pin = RPI_GPIO_P1_05;
-		data2pin = RPI_GPIO_P1_07;
+		data1pin = RPI_GPIO_P1_07;
+		data2pin = RPI_GPIO_P1_05;
 		clockpin_v2 = RPI_V2_GPIO_P1_19;
 		strobepin_v2 = RPI_V2_GPIO_P1_23;
 		data1pin_v2 = RPI_V2_GPIO_P1_07;


### PR DESCRIPTION
the pin out for version 1x does not match the pin out described in the retropie GPIO pin out here http://blog.petrockblock.com/2012/10/21/the-retropie-gpio-adapter/