### PR TITLE
Added Additional Button

### DIFF
--- a/src/SNESDev.c
+++ b/src/SNESDev.c
@@ -303,6 +303,8 @@ int main(int argc, char *argv[]) {
 						BTN_SELECT, &uinp_gpads[ctr]);
 				processPadBtn(gpads[ctr].state, EV_KEY, GPAD_SNES_START,
 						BTN_START, &uinp_gpads[ctr]);
+				processPadBtn(gpads[ctr].state, EV_KEY, GPAD_SNES_HOME,
+						BTN_MODE, &uinp_gpads[ctr]);
 
 				if ((gpads[ctr].state & GPAD_SNES_LEFT) == GPAD_SNES_LEFT) {
 					uinput_gpad_write(&uinp_gpads[ctr], ABS_X, 0, EV_ABS);

--- a/src/SNESDev.c
+++ b/src/SNESDev.c
@@ -304,7 +304,7 @@ int main(int argc, char *argv[]) {
 				processPadBtn(gpads[ctr].state, EV_KEY, GPAD_SNES_START,
 						BTN_START, &uinp_gpads[ctr]);
 				processPadBtn(gpads[ctr].state, EV_KEY, GPAD_SNES_HOME,
-						BTN_MODE, &uinp_gpads[ctr]);
+						BTN_TL2, &uinp_gpads[ctr]);
 
 				if ((gpads[ctr].state & GPAD_SNES_LEFT) == GPAD_SNES_LEFT) {
 					uinput_gpad_write(&uinp_gpads[ctr], ABS_X, 0, EV_ABS);

--- a/src/gamepad.h
+++ b/src/gamepad.h
@@ -41,6 +41,8 @@
 #define GPAD_SNES_X       0x200
 #define GPAD_SNES_L       0x400
 #define GPAD_SNES_R       0x800
+#define GPAD_SNES_HOME    0x1000
+
 
 /* bit masks for checking the button states for NES controllers */
 #define GPAD_NES_B       0x01

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -86,6 +86,7 @@ int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type) {
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_TR);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_SELECT);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_START);
+	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_MODE);
 	// gamepad, directions
 	ioctl(gpad->fd, UI_SET_EVBIT, EV_ABS);
 	ioctl(gpad->fd, UI_SET_ABSBIT, ABS_X);


### PR DESCRIPTION
Added support for a 9th button on input Byte 0x1000, this has been tied to the BTN_TL2 and can be configured as desired. This allows users of the Monster Joysticks all in one to use the front button on the stick.